### PR TITLE
支持Openssl 3.0及以上版本

### DIFF
--- a/libtransmission/crypto-utils-openssl.c
+++ b/libtransmission/crypto-utils-openssl.c
@@ -20,6 +20,9 @@
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#if OPENSSL_VERSION_MAJOR >= 3
+#include <openssl/provider.h>
+#endif
 
 #include "transmission.h"
 #include "crypto-utils.h"
@@ -184,6 +187,10 @@ static void openssl_evp_cipher_context_free(EVP_CIPHER_CTX* handle)
 
 tr_rc4_ctx_t tr_rc4_new(void)
 {
+#if OPENSSL_VERSION_MAJOR >= 3
+    OSSL_PROVIDER_load(NULL, "default");
+    OSSL_PROVIDER_load(NULL, "legacy");
+#endif
     EVP_CIPHER_CTX* handle = EVP_CIPHER_CTX_new();
 
     if (check_result(EVP_CipherInit_ex(handle, EVP_rc4(), NULL, NULL, NULL, -1)))


### PR DESCRIPTION
该补丁来自[Gentoo](https://gitweb.gentoo.org/repo/gentoo.git/tree/net-p2p/transmission/files/transmission-3.00-openssl-3.patch)

Debian维护者的补丁少了一个free，会导致内存泄露，参见：
[ref#1](https://github.com/transmission/transmission/issues/4716)
[ref#2](https://bugs.launchpad.net/bugs/1946215)
[ref#3](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006584)